### PR TITLE
Api proxy

### DIFF
--- a/SE-Frontend/src/App.vue
+++ b/SE-Frontend/src/App.vue
@@ -10,6 +10,7 @@ import HelloWorld from './components/HelloWorld.vue'
     <div class="wrapper">
       <HelloWorld msg="You did it!" />
 
+
       <nav>
         <RouterLink to="/">Home</RouterLink>
         <RouterLink to="/about">About</RouterLink>

--- a/SE-Frontend/vite.config.js
+++ b/SE-Frontend/vite.config.js
@@ -10,5 +10,18 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
-  }
+  },
+  server: {
+    host: '127.0.0.1',//本机ip
+    port: 5173,
+    open: true, //自动打开 
+    //base: "./ ", //生产环境路径
+    proxy: {
+      '/api': {
+        target: 'http://59.110.140.64',	//实际请求地址
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    }
+  },
 })


### PR DESCRIPTION
将后端服务器ip代理为“/api”，解决ajax请求跨域问题。